### PR TITLE
Fixes constants which contains underscores.

### DIFF
--- a/src/Ixudra/Curl/Builder.php
+++ b/src/Ixudra/Curl/Builder.php
@@ -219,7 +219,7 @@ class Builder {
     {
         $results = array();
         foreach( $this->curlOptions as $key => $value ) {
-            $array_key = constant( 'CURLOPT_' . str_replace('_', '', $key) );
+            $array_key = constant( 'CURLOPT_' . $key );
 
             if( $key == 'POST_FIELDS' && is_array( $value ) ) {
                 $results[ $array_key ] = http_build_query( $value, null, '&' );


### PR DESCRIPTION
Example: `SSL_VERIFYPEER` would renamed to `SSLVERIFYPEER` which results in the following error: `Couldn't find constant CURLOPT_SSLVERIFYPEER`