### PR TITLE
Fixes constants which contains underscores 2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ixudra/curl",
+    "name": "kevinvdburgt/curl-hotfix",
     "description": "Custom PHP Curl library for the Laravel 5 framework - developed by Ixudra",
     "version": "6.0.0",
     "keywords": ["Ixudra", "Laravel", "Curl"],

--- a/src/Ixudra/Curl/Builder.php
+++ b/src/Ixudra/Curl/Builder.php
@@ -115,7 +115,7 @@ class Builder {
      */
     public function withHeader($header)
     {
-        $this->curlOptions[ 'HTTP_HEADER' ][] = $header;
+        $this->curlOptions[ 'HTTPHEADER' ][] = $header;
     }
 
     /**
@@ -157,7 +157,7 @@ class Builder {
             $parameters = json_encode($parameters);
         }
 
-        $this->curlOptions[ 'POST_FIELDS' ] = $parameters;
+        $this->curlOptions[ 'POSTFIELDS' ] = $parameters;
     }
 
 //    /**
@@ -221,7 +221,7 @@ class Builder {
         foreach( $this->curlOptions as $key => $value ) {
             $array_key = constant( 'CURLOPT_' . $key );
 
-            if( $key == 'POST_FIELDS' && is_array( $value ) ) {
+            if( $key == 'POSTFIELDS' && is_array( $value ) ) {
                 $results[ $array_key ] = http_build_query( $value, null, '&' );
             } else {
                 $results[ $array_key ] = $value;

--- a/src/Ixudra/Curl/Builder.php
+++ b/src/Ixudra/Curl/Builder.php
@@ -6,15 +6,15 @@ class Builder {
     protected $curlObject = null;
 
     protected $curlOptions = array(
-        'RETURN_TRANSFER'       => true,
-        'FAIL_ON_ERROR'         => true,
-        'FOLLOW_LOCATION'       => false,
-        'CONNECT_TIMEOUT'       => '',
+        'RETURNTRANSFER'        => true,
+        'FAILONERROR'           => true,
+        'FOLLOWLOCATION'        => false,
+        'CONNECTTIMEOUT'        => '',
         'TIMEOUT'               => 30,
-        'USER_AGENT'            => '',
+        'USERAGENT'             => '',
         'URL'                   => '',
         'POST'                  => false,
-        'HTTP_HEADER'           => array(),
+        'HTTPHEADER'            => array(),
     );
 
     protected $packageOptions = array(


### PR DESCRIPTION
The `protected $curlOptions` keys where renamed. Changed them to the correct names documented on this page: http://php.net/manual/en/function.curl-setopt.php