### PR TITLE
Fixes bug where data is omitted by HTTP in DELETE requests by sending…

### DIFF
--- a/src/Ixudra/Curl/Builder.php
+++ b/src/Ixudra/Curl/Builder.php
@@ -227,12 +227,7 @@ class Builder {
      */
     public function get()
     {
-        $parameterString = '';
-        if( is_array($this->packageOptions[ 'data' ]) && count($this->packageOptions[ 'data' ]) != 0 ) {
-            $parameterString = '?'. http_build_query($this->packageOptions[ 'data' ]);
-        }
-
-        $this->curlOptions[ 'URL' ] .= $parameterString;
+        $this->appendDataToURL();
 
         return $this->send();
     }
@@ -310,6 +305,8 @@ class Builder {
      */
     public function delete()
     {
+        $this->appendDataToURL();
+
         return $this->withOption('CUSTOMREQUEST', 'DELETE')
             ->send();
     }
@@ -404,4 +401,18 @@ class Builder {
         return $results;
     }
 
+    /**
+     * Append set data to the query string for GET and DELETE cURL requests
+     *
+     * @return string
+     */
+    protected function appendDataToURL()
+    {
+        $parameterString = '';
+        if( is_array($this->packageOptions[ 'data' ]) && count($this->packageOptions[ 'data' ]) != 0 ) {
+            $parameterString = '?'. http_build_query($this->packageOptions[ 'data' ]);
+        }
+
+        return $this->curlOptions[ 'URL' ] .= $parameterString;
+    }
 }


### PR DESCRIPTION
After investigating why my delete requests were returning false for me, I found out I was attempting to pass data in the body of the request and this was triggering a silent error and since `CURLOPT_FAILONERROR` is enabled it would fail. After disabling it, the request would submit but without data. This fix allows FAILONERROR to stay enabled but correctly pass data along with DELETE requests.

This is in reference to issue #26 

Where I found the issue about DELETE requests omitting were omitting the data.
http://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request