### PR TITLE
Adding curl error messages to response body if they occur.

### DIFF
--- a/src/Ixudra/Curl/Builder.php
+++ b/src/Ixudra/Curl/Builder.php
@@ -340,8 +340,10 @@ class Builder {
         $responseData = array();
         if( $this->packageOptions[ 'responseObject' ] ) {
             $responseData = curl_getinfo( $this->curlObject );
+            if(curl_errno($this->curlObject)){
+                $responseData['errorMessage'] = curl_error($this->curlObject);
+            }
         }
-
         curl_close( $this->curlObject );
 
         if( $this->packageOptions[ 'saveFile' ] ) {
@@ -376,6 +378,7 @@ class Builder {
         $object = new stdClass();
         $object->content = $content;
         $object->status = $responseData[ 'http_code' ];
+        $object->error = $responseData['errorMessage'];
 
         return $object;
     }


### PR DESCRIPTION
Pull request to add functionalities requested on #23 

It was implemented like this:
```
{
   "content": false
   "status": 404
   "error": "The requested URL returned error: 404 Not Found"
}
```
