### PR TITLE
fix curl service provider to support laravel 5.4

### DIFF
--- a/src/Ixudra/Curl/CurlServiceProvider.php
+++ b/src/Ixudra/Curl/CurlServiceProvider.php
@@ -15,9 +15,8 @@ class CurlServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['Curl'] = $this->app->share(
-            function($app)
-            {
+        $this->app->singleton('Curl',
+            function () {
                 return new CurlService();
             }
         );


### PR DESCRIPTION
seems to work with this simple fix as outlined in the Laravel 5.4 upgrade guide to change the use of the share() method to singleton().

https://laravel.com/docs/5.4/upgrade