### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Pull this package in through Composer.
 
 ```
 
+or run in terminal:
+`composer require ixudra/curl`
+
 
 ### Laravel 5.* Integration
 
@@ -140,22 +143,28 @@ method.
 In order to send a `GET` request, you need to use the `get()` method that is provided by the package:
 
 ```php
+use Ixudra\Curl\Facades\Curl;
 
-    // Send a GET request to: http://www.foo.com/bar
-    $response = Curl::to('http://www.foo.com/bar')
-        ->get();
+class Foo
+{
+    public function bar ()
+    {
+        // Send a GET request to: http://www.foo.com/bar
+        $response = Curl::to('http://www.foo.com/bar')
+            ->get();
 
-    // Send a GET request to: http://www.foo.com/bar?foz=baz
-    $response = Curl::to('http://www.foo.com/bar')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->get();
+        // Send a GET request to: http://www.foo.com/bar?foz=baz
+        $response = Curl::to('http://www.foo.com/bar')
+            ->withData( array( 'foz' => 'baz' ) )
+            ->get();
 
-    // Send a GET request to: http://www.foo.com/bar?foz=baz using JSON
-    $response = Curl::to('http://www.foo.com/bar')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->asJson()
-        ->get();
-
+        // Send a GET request to: http://www.foo.com/bar?foz=baz using JSON
+        $response = Curl::to('http://www.foo.com/bar')
+            ->withData( array( 'foz' => 'baz' ) )
+            ->asJson()
+            ->get();
+    }
+}
 ```
 
 
@@ -169,7 +178,7 @@ use Ixudra\Curl\Facades\Curl;
 class Foo
 {
     public function bar ()
-        {
+    {
         // Send a POST request to: http://www.foo.com/bar
         $response = Curl::to('http://www.foo.com/bar')
             ->post();
@@ -190,9 +199,8 @@ class Foo
             ->withData( array( 'foz' => 'baz' ) )
             ->asJson( true )
             ->post();
-        }
+    }
 }
-
 ```
 
 
@@ -201,13 +209,19 @@ class Foo
 Put requests work similar to `POST` requests, but use the `put()` method instead:
 
 ```php
+use Ixudra\Curl\Facades\Curl;
 
-    // Send a PUT request to: http://www.foo.com/bar/1 with arguments 'foz' = 'baz' using JSON
-    $response = Curl::to('http://www.foo.com/bar/1')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->asJson()
-        ->put();
-
+class Foo
+{
+    public function bar ()
+    {
+        // Send a PUT request to: http://www.foo.com/bar/1 with arguments 'foz' = 'baz' using JSON
+        $response = Curl::to('http://www.foo.com/bar/1')
+           ->withData( array( 'foz' => 'baz' ) )
+           ->asJson()
+           ->put();
+    }
+}
 ```
 
 
@@ -216,13 +230,19 @@ Put requests work similar to `POST` requests, but use the `put()` method instead
 Patch requests work similar to `POST` requests, but use the `patch()` method instead:
 
 ```php
+use Ixudra\Curl\Facades\Curl;
 
-    // Send a PATCH request to: http://www.foo.com/bar/1 with arguments 'foz' = 'baz' using JSON
-    $response = Curl::to('http://www.foo.com/bar/1')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->asJson()
-        ->patch();
-
+class Foo
+{
+    public function bar ()
+    {
+        // Send a PATCH request to: http://www.foo.com/bar/1 with arguments 'foz' = 'baz' using JSON
+        $response = Curl::to('http://www.foo.com/bar/1')
+            ->withData( array( 'foz' => 'baz' ) )
+            ->asJson()
+            ->patch();
+    }
+}
 ```
 
 
@@ -231,12 +251,18 @@ Patch requests work similar to `POST` requests, but use the `patch()` method ins
 Delete requests work similar to `GET` requests, but use the `delete()` method instead:
 
 ```php
+use Ixudra\Curl\Facades\Curl;
 
-    // Send a DELETE request to: http://www.foo.com/bar/1 using JSON
-    $response = Curl::to('http://www.foo.com/bar/1')
-        ->asJson()
-        ->delete();
-
+class Foo
+{
+    public function bar ()
+    {
+        // Send a DELETE request to: http://www.foo.com/bar/1 using JSON
+        $response = Curl::to('http://www.foo.com/bar/1')
+            ->asJson()
+            ->delete();
+    }
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ well as the response content:
 
 The response object will look like this:
 
-```
+```json
 {
    "content": 'Message content here',
    "status": 200,

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The response object will look like this:
 {
    "content": "Message content here",
    "status": 200,
-   "error": "Error message goes here"       // Only added if an error occurs
+   "error": "Error message goes here (Only added if an error occurs)"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Add the facade to your `config/app.php` file:
 
 ```php
 
-    'facades'       => array(
+    'aliases'       => [
 
         //...
         'Curl'          => Ixudra\Curl\Facades\Curl::class,
 
-    ),
+    ],
 
 ```
 
@@ -164,27 +164,34 @@ In order to send a `GET` request, you need to use the `get()` method that is pro
 Post requests work similar to `GET` requests, but use the `post()` method instead:
 
 ```php
+use Ixudra\Curl\Facades\Curl;
 
-    // Send a POST request to: http://www.foo.com/bar
-    $response = Curl::to('http://www.foo.com/bar')
-        ->post();
+class Foo
+{
+    public function bar ()
+        {
+        // Send a POST request to: http://www.foo.com/bar
+        $response = Curl::to('http://www.foo.com/bar')
+            ->post();
 
-    // Send a POST request to: http://www.foo.com/bar
-    $response = Curl::to('http://www.foo.com/bar')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->post();
+        // Send a POST request to: http://www.foo.com/bar
+        $response = Curl::to('http://www.foo.com/bar')
+            ->withData( array( 'foz' => 'baz' ) )
+            ->post();
 
-    // Send a POST request to: http://www.foo.com/bar with arguments 'foz' = 'baz' using JSON
-    $response = Curl::to('http://www.foo.com/bar')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->asJson()
-        ->post();
+        // Send a POST request to: http://www.foo.com/bar with arguments 'foz' = 'baz' using JSON
+        $response = Curl::to('http://www.foo.com/bar')
+            ->withData( array( 'foz' => 'baz' ) )
+            ->asJson()
+            ->post();
 
-    // Send a POST request to: http://www.foo.com/bar with arguments 'foz' = 'baz' using JSON and return as associative array
-    $response = Curl::to('http://www.foo.com/bar')
-        ->withData( array( 'foz' => 'baz' ) )
-        ->asJson( true )
-        ->post();
+        // Send a POST request to: http://www.foo.com/bar with arguments 'foz' = 'baz' using JSON and return as associative array
+        $response = Curl::to('http://www.foo.com/bar')
+            ->withData( array( 'foz' => 'baz' ) )
+            ->asJson( true )
+            ->post();
+        }
+}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -332,9 +332,9 @@ The response object will look like this:
 
 ```json
 {
-   "content": 'Message content here',
+   "content": "Message content here",
    "status": 200,
-   "error": 'Error message goes here'       // Only added if an error occurs
+   "error": "Error message goes here"       // Only added if an error occurs
 }
 ```
 


### PR DESCRIPTION
Some things were broken in the README file.

The Laravel 5.* `facades` array no longer exist and the correct "Use" link to the lib was missing in the examples.

Also, JSON syntax highlight was added.