### PR TITLE
added parameter for HTTPS requests compability

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -19,6 +19,7 @@ class Builder {
         'URL'                   => '',
         'POST'                  => false,
         'HTTPHEADER'            => array(),
+        'SSL_VERIFYPEER'        => false,
     );
 
     /** @var array $packageOptions      Array with options that are not specific to cURL but are used by the package */


### PR DESCRIPTION
hello, I tried to parse a site via HTTPS and failed without this option, now it works fine, please accept