### PR TITLE
Add support for fractional timeout seconds

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -50,12 +50,12 @@ class Builder {
     /**
      * Set the request timeout
      *
-     * @param   integer $timeout    The timeout for the request (in seconds. Default: 30 seconds)
+     * @param   float $timeout    The timeout for the request (in seconds, fractions of a second are okay. Default: 30 seconds)
      * @return Builder
      */
     public function withTimeout($timeout = 30)
     {
-        return $this->withCurlOption( 'TIMEOUT', $timeout );
+        return $this->withCurlOption( 'TIMEOUT_MS', ($timeout * 1000) );
     }
 
     /**


### PR DESCRIPTION
In order to support fractions of a second timeouts (e.g. 1.5 seconds), this change makes use of `CURLOPT_TIMEOUT_MS` in the `withTimeout()` method. 

The method parameter is still seconds, but is multiplied by 1000 to convert to MS and make compatible with CURLOPT_TIMEOUT_MS.

This change is backwards compatible.