### PR TITLE
Add content-type response header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ The response object will look like this:
 {
    "content": "Message content here",
    "status": 200,
+   "contentType": "content-type response header (ex: application/json)",
    "error": "Error message goes here (Only added if an error occurs)"
 }
 ```

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -489,6 +489,7 @@ class Builder {
         $object = new stdClass();
         $object->content = $content;
         $object->status = $responseData[ 'http_code' ];
+        $object->contentType = $responseData[ 'content_type' ];
         if( array_key_exists('errorMessage', $responseData) ) {
             $object->error = $responseData[ 'errorMessage' ];
         }


### PR DESCRIPTION
When you use `->returnResponseObject()`, you don't get the `content-type` header back 

This a gap between this curl and the actual HTTP protocol / vanilla CURL.  

Most people are sticking to one known content type, but I think it would be closer to 1:1 with HTTP if we could also get the response `content-type` back with the response headers.  (I'm using this package in scenarios where the response content type is variable actually).

In my PR, I tried to use reasonable naming conventions that match yours and I also updated the example in the readme.  Please let me know if anything is to be updated.  Thanks!