### PR TITLE
Add XML options to curl builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ixudra/curl
 ================
+MODIFIED VERSION
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/ixudra/curl.svg?style=flat-square)](https://packagist.org/packages/ixudra/curl)
 [![license](https://img.shields.io/github/license/ixudra/curl.svg)]()

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -26,14 +26,14 @@ class Builder {
     /** @var array $packageOptions      Array with options that are not specific to cURL but are used by the package */
     protected $packageOptions = array(
         'data'                  => array(),
-        'xml'                   => null,
+        'xml'                   => null, //the withXML() method will assign an xml string (or any string) to this property
         'files'                 => array(),
         'asJsonRequest'         => false,
         'asJsonResponse'        => false,
-
-        'asUrlEncoded'          => false,
-        'asXMLRequest'          => false,
-        'asXMLResponse'         => false,
+        
+        'asUrlEncoded'          => false, // attaches the header 'Content-Type: application/x-www-form-urlencoded' 
+        'asXMLRequest'          => false, // attaches the header 'Content-Type: text/xml' with the request
+        'asXMLResponse'         => false, // return unparsed (hopefully xml) data from the response as a string
 
         'returnAsArray'         => false,
         'responseObject'        => false,
@@ -71,22 +71,29 @@ class Builder {
     /**
      * Add GET or POST data to the request
      *
-     * @param   mixed $data     Array of data that is to be sent along with the request
+     * @param   array|null|string $data     Array of data that is to be sent along with the request
      * @return Builder
      */
     public function withData($data = array())
     {
-        return $this->withPackageOption( 'data', $data );
+        if($data && $this->packageOptions[ 'asXMLRequest' ] ){
+            $this->withXML($data);
+        } else {       
+            return $this->withPackageOption( 'data', $data );
+        }
     }
 
     /**
-     * Add GET or POST data to the request
+     * Add XML data to the request
      *
-     * @param   mixed $data     Array of data that is to be sent along with the request
+     * @param   string $xml     This should be a raw XML string that will be sent with the request
      * @return Builder
      */
     public function withXML(string $xml)
     {
+        if($xml && !is_string($xml)){
+            throw new \InvalidArgumentException("XML requests require an XML string. You provided a ". gettype($xml) );
+        }
         return $this->withPackageOption( 'xml', $xml );
     }
 
@@ -132,8 +139,7 @@ class Builder {
     }
 
     /**
-     * Configure the package to encode and decode the request data as XML
-     * @param   boolean $asArray    Indicates whether or not the data should be returned as an array. Default: false
+     * Configure the package to attach the 'Content-Type: text/xml' 
      * @return Builder
      */
     public function asXML(){

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -154,7 +154,7 @@ class Builder {
      * Set any specific cURL option
      *
      * @param   string $key         The name of the cURL option
-     * @param   string $value       The value to which the option is to be set
+     * @param   mixed  $value       The value to which the option is to be set
      * @return Builder
      */
     public function withOption($key, $value)


### PR DESCRIPTION
I love the library, and use it quite heavily. 
I deal with some xml apis, so I've added a few small additions to make this library easier to use with XML apis. 

If you feel like it would be helpful to others, feel free to merge it. 

Example Use Case:
```
 $curl = \Utils\Curl::to($url)
            ->withHeaders(static::get_request_headers())
            ->withTimeout(10)
            ->returnResponseArray();
        
        switch($type){
            case "json": 
                $curl->asJson(true)->withData($data);
                break;
            case "xml": 
                $data = $this->xml_encode_request_data($data);
                $curl->asXML()->withXml($data);
                break;
            default: 
                $curl->asUrlEncoded()->withData($data);
                break;
        }
```