### PR TITLE
set: default SSL_VERIFYPEER as true

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -19,7 +19,7 @@ class Builder {
         'URL'                   => '',
         'POST'                  => false,
         'HTTPHEADER'            => array(),
-        'SSL_VERIFYPEER'        => false,
+        'SSL_VERIFYPEER'        => true,
         'NOBODY'                => false,
         'HEADER'                => false,
     );


### PR DESCRIPTION
I think this better when we always set `SSL_VERIFYPEER` as `true` for security reason.

And default of `CURLOPT_SSL_VERIFYPEER` is "[true](https://www.php.net/manual/en/reserved.constants.php#constant.true) by default as of cURL 7.10. Default bundle installed as of cURL 7.10."