### PR TITLE
Save response as error in case json_decode() fails.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -195,7 +195,7 @@ class Builder {
     {
         return $this->withOption( 'COOKIEJAR', $cookieJar );
     }
-    
+
     /**
      * Set any specific cURL option
      *
@@ -569,8 +569,14 @@ class Builder {
             fwrite($file, $response);
             fclose($file);
         } else if( $this->packageOptions[ 'asJsonResponse' ] ) {
-            // Decode the request if necessary
+            $response_original = $response;
+            // Decode the request if necessary.
             $response = json_decode($response, $this->packageOptions[ 'returnAsArray' ]);
+
+            if (is_null($response) && is_string($response_original)) {
+              // It's likely that the response includes an error message.
+              $responseData[ 'errorMessage' ] = $response_original;
+            }
         }
 
         if( $this->packageOptions[ 'enableDebug' ] ) {


### PR DESCRIPTION
## Background

Sometimes it may happen that the reponse from cURL isn't valid JSON, so `json_decode()` in `Builder::send()` fails and returns `NULL`.

Example: requesting data from _toggl_ may result in an error when reaching the hourly API limit. In this case, `$response` does not contain any valid JSON but a simple error message (e.g. "You have hit your hourly limit for API calls. Please upgrade to a paid plan for increased access. Your quota will reset in 2513 seconds. CTA: Go to subscriptions page.").

## Proposal

In case of errors save the original response as error message so the caller is able to react accordingly.

## Example usage

```
$data = $this->getCurlService()
        ->to($url)
        ->withOption('USERPWD', $this->apiToken . ':api_token')
        ->withData($data)
        ->returnResponseArray()
        ->asJson()
        ->get();

if (isset($data['status']) && ($data['status'] === 402)) {
  $message_default = 'You have reached your hourly API limit. Please try again later.';
  throw new ApiLimitException($data['error'] ?? $message_default);
}

```
